### PR TITLE
Add versions of #ds/pp, #ds/pt, #ds/i and #ds/it for use in threading.

### DIFF
--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -126,8 +126,16 @@
  ds/trie  data-scope.graphs/scope-trie
  ds/dot   data-scope.graphs/scope-dot
 
- ds/pp data-scope.pprint/scope-pprint
- ds/pt data-scope.pprint/scope-print-table
+ ds/pp    data-scope.pprint/scope-pprint
+ ds/pp->> data-scope.pprint/scope-pprint-thread-last
+ ds/pp->  data-scope.pprint/scope-pprint-thread-first
+ ds/pt    data-scope.pprint/scope-print-table
+ ds/pt->> data-scope.pprint/scope-print-table-thread-last
+ ds/pt->  data-scope.pprint/scope-print-table-thread-first
 
- ds/i  data-scope.inspect/scope-inspect-tree
- ds/it data-scope.inspect/scope-inspect-table}
+ ds/i     data-scope.inspect/scope-inspect-tree
+ ds/i->>  data-scope.inspect/scope-inspect-tree-thread-last
+ ds/i->   data-scope.inspect/scope-inspect-tree-thread-first
+ ds/it    data-scope.inspect/scope-inspect-table
+ ds/it->> data-scope.inspect/scope-inspect-table-thread-last
+ ds/it->  data-scope.inspect/scope-inspect-table-thread-first}

--- a/src/data_scope/inspect.clj
+++ b/src/data_scope/inspect.clj
@@ -12,5 +12,32 @@
 
 (defn scope-inspect-tree [form]
   `(let [form# ~form] ('~inspector/inspect-tree form#) form#))
+
+(defn scope-inspect-tree-thread-last [form]
+  `((fn [x#]
+      (let [form# (->> x# ~form)]
+        ('~inspector/inspect-tree form#)
+        form#))))
+
+(defn scope-inspect-tree-thread-first [form]
+  `((fn [x#]
+      (let [form# (-> x# ~form)]
+        ('~inspector/inspect-tree form#)
+        form#))))
+
 (defn scope-inspect-table [form]
-  `(let [form# ~form] (~inspect-table form#) form#))
+  `(let [form# ~form]
+     (~inspect-table form#)
+     form#))
+
+(defn scope-inspect-table-thread-last [form]
+  `((fn [x#]
+      (let [form# (->> x# ~form)]
+        (~inspect-table form#)
+        form#))))
+
+(defn scope-inspect-table-thread-first [form]
+  `((fn [x#]
+      (let [form# (-> x# ~form)]
+        (~inspect-table form#)
+        form#))))

--- a/src/data_scope/pprint.clj
+++ b/src/data_scope/pprint.clj
@@ -13,7 +13,31 @@
      ('~pprint/pprint form#)
      form#))
 
+(defn scope-pprint-thread-last [form]
+  `((fn [x#]
+      (let [form# (->> x# ~form)]
+        ('~pprint/pprint form#)
+        form#))))
+
+(defn scope-pprint-thread-first [form]
+  `((fn [x#]
+      (let [form# (-> x# ~form)]
+        ('~pprint/pprint form#)
+        form#))))
+
 (defn scope-print-table [form]
   `(let [form# ~form]
      (~print-table form#)
      form#))
+
+(defn scope-print-table-thread-last [form]
+  `((fn [x#]
+      (let [form# (->> x# ~form)]
+        (~print-table form#)
+        form#))))
+
+(defn scope-print-table-thread-first [form]
+  `((fn [x#]
+      (let [form# (-> x# ~form)]
+        (~print-table form#)
+        form#))))


### PR DESCRIPTION
It's often useful to be able to inspect the intermediery results of a pipeline
creating using threading macros (->>, -> and friends).

These additions make it simple to use some of data-scope inside pipelines, for
example:
(->> [1 2 3]
     #ds/pp->> (map (fn [x] (inc x)))
     (map (fn [x] (* x x))))